### PR TITLE
[UPDATE] Atualiza o requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-filter==1.0.4
 django-hosts==2.0
 django-localflavor==1.1
 django-piwik==0.1
-django-smart-selects==1.1.1
+https://pypi.python.org/packages/source/d/django-smart-selects/django-smart-selects-1.1.1.tar.gz
 django-widget-tweaks==1.3
 django-wkhtmltopdf==2.0.2
 djangorestframework==3.6.4
@@ -41,3 +41,4 @@ urllib3==1.22
 Werkzeug==0.11
 XlsxWriter==1.0.0
 xlwt==1.0.0
+-e git+https://github.com/Artory/drf-hal-json#egg=drf-hal-json


### PR DESCRIPTION
Força a versão 1.1.1 do django-smart-selects instalada via URL e também o drf-hal-json via git.