### PR TITLE
[FIX] Corrige título para município e estado na tela de gestao

### DIFF
--- a/snc/templates/gestao/detalhe_municipio.html
+++ b/snc/templates/gestao/detalhe_municipio.html
@@ -9,10 +9,11 @@
               <div class="row">
                   <div class="col-md-7">
                     <p><strong>Localização: </strong></p>
-                    <p><strong>Município:</strong>
                       {% if object.municipio.cidade == None  %}
+                        <p><strong>Estado:</strong>
                        {{ object.municipio.estado }}
                       {% else %}
+                        <p><strong>Município:</strong>
                         {{object.municipio.cidade}}-{{ object.municipio.estado }}
                       {% endif %}
                      </p>


### PR DESCRIPTION
Corrige problema de aparecer o título **Município** tanto para um ente federado estadual quanto para o municipal.