### PR TITLE
Retira dependência do django_hosts e corrige urls

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -5,7 +5,7 @@ from drf_hal_json import serializers as hal_serializers
 from adesao.models import Municipio, Uf, Cidade, Usuario
 from planotrabalho.models import (PlanoTrabalho, CriacaoSistema, OrgaoGestor,
 ConselhoCultural, FundoCultura, PlanoCultura, Conselheiro, SituacoesArquivoPlano)
-from drf_hal_json.fields import HalHyperlinkedRelatedField, HalContributeToLinkField
+from drf_hal_json.fields import HalHyperlinkedIdentityField
 import json
 
 # Criacao do Sistema 
@@ -68,6 +68,7 @@ class PlanoTrabalhoSerializer(hal_serializers.HalModelSerializer):
     criacao_fundo_cultura = serializers.SerializerMethodField(source= 'fundo_cultura')
     criacao_conselho_cultural = serializers.SerializerMethodField(source= 'conselho_cultural')
     _embedded = serializers.SerializerMethodField(method_name='get_embedded')
+    self = HalHyperlinkedIdentityField(view_name='api:planotrabalho-detail')
 
     class Meta:
         model = PlanoTrabalho
@@ -141,7 +142,7 @@ class UsuarioSerializer(hal_serializers.HalModelSerializer):
         model = Usuario
         fields = ('responsavel','estado_processo',
                   'data_publicacao_acordo','plano_trabalho')
-    
+
 # Cidade        
 class CidadeSerializer(serializers.ModelSerializer):
     class Meta:
@@ -154,7 +155,7 @@ class UfSerializer(serializers.ModelSerializer):
         fields = ('codigo_ibge', 'sigla')
 
 class MunicipioLinkSerializer(hal_serializers.HalModelSerializer):
-
+    self = HalHyperlinkedIdentityField(view_name='api:municipio-detail')
     class Meta:
         model = Municipio
         fields = ('self',)
@@ -166,6 +167,7 @@ class MunicipioSerializer(hal_serializers.HalModelSerializer):
     conselho = serializers.SerializerMethodField()
     _embedded = serializers.SerializerMethodField(method_name='get_embedded')
     situacao_adesao = serializers.SerializerMethodField()
+    self = HalHyperlinkedIdentityField(view_name='api:municipio-detail')
     
     class Meta:
         model = Municipio

--- a/api/static/swagger/swagger.json
+++ b/api/static/swagger/swagger.json
@@ -5,7 +5,7 @@
       "version": "0.1-beta",
       "title": "SNC API"
     },
-    "host": "api.localhost:8000/",
+    "host": "localhost:8000/api/",
     "basePath": "v1",
     "schemes": [
       "http"

--- a/api/tests.py
+++ b/api/tests.py
@@ -7,13 +7,12 @@ from model_mommy import mommy
 
 pytestmark = pytest.mark.django_db
 
-url_sistemadeculturalocal = '/v1/sistemadeculturalocal/'
-url_acoesplanotrabalho = '/v1/acoesplanotrabalho/'
-host_request = 'api'
+url_sistemadeculturalocal = '/api/v1/sistemadeculturalocal/'
+url_acoesplanotrabalho = '/api/v1/acoesplanotrabalho/'
 
 def test_municipios_list_endpoint_returning_200_OK(client):
 
-    request = client.get(url_sistemadeculturalocal, HTTP_HOST=host_request)
+    request = client.get(url_sistemadeculturalocal)
 
     assert request.status_code == status.HTTP_200_OK
 
@@ -22,7 +21,7 @@ def test_URL_sistema_cultura_local_retorna_10_sistemas(client):
 
     sistemas = mommy.make('Municipio', _quantity=12)
 
-    request = client.get(url_sistemadeculturalocal, HTTP_HOST=host_request,
+    request = client.get(url_sistemadeculturalocal,
                          content_type="application/hal+json")
 
     assert isinstance(request.data["_embedded"]["items"], list)
@@ -33,8 +32,7 @@ def test_404_recupera_ID_sistema_cultura_local(client):
 
     url = url_sistemadeculturalocal + '45/'
 
-    request = client.get(url, HTTP_HOST=host_request,
-                        content_type="application/hal+json")
+    request = client.get(url,content_type="application/hal+json")
 
     assert request.status_code == status.HTTP_404_NOT_FOUND
 
@@ -47,8 +45,7 @@ def test_recupera_ID_param_sistema_cultura_local(client):
     url = url_sistemadeculturalocal + municipio_id
 
 
-    request = client.get(url, HTTP_HOST=host_request,
-                        content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     assert request.status_code == status.HTTP_200_OK
     assert request.data["id"] == municipio.id
@@ -61,7 +58,7 @@ def test_entidades_principais_sistema_cultura_local(client):
 
     url = url_sistemadeculturalocal + municipio_id
 
-    request = client.get(url, HTTP_HOST=host_request, content_type="application/hal+json")
+    request = client.get(url,content_type="application/hal+json")
 
     entidades = set(["governo","ente_federado", "conselho",
         "_embedded","situacao_adesao","_links","id"])
@@ -76,8 +73,7 @@ def test_campos_do_objeto_governo_ao_retornar_sistema_cultura_local(client):
 
     url = url_sistemadeculturalocal + municipio_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-                         content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["nome_prefeito", "email_institucional_prefeito",
                   "termo_posse_prefeito"])
@@ -92,8 +88,7 @@ def test_campos_do_objeto_ente_federado_ao_retornar_sistema_cultura_local(client
 
     url = url_sistemadeculturalocal + municipio_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["cnpj_prefeitura","endereco_eletronico","telefones","localizacao"])
 
@@ -107,8 +102,7 @@ def test_campos_do_objeto_embedded_ao_retornar_sistema_cultura_local(client):
 
     url = url_sistemadeculturalocal + municipio_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["acoes_plano_trabalho"])
 
@@ -126,8 +120,7 @@ def test_campos_do_objeto_conselho_ao_retornar_sistema_cultura_local(client):
 
     url = url_sistemadeculturalocal + municipio_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["conselheiros"])
 
@@ -136,7 +129,7 @@ def test_campos_do_objeto_conselho_ao_retornar_sistema_cultura_local(client):
 
 def test_planotrabalho_list_endpoint_returning_200_OK(client):
 
-    request = client.get(url_acoesplanotrabalho, HTTP_HOST=host_request)
+    request = client.get(url_acoesplanotrabalho)
 
     assert request.status_code == status.HTTP_200_OK
 
@@ -145,7 +138,7 @@ def test_planotrabalho_list_retorna_lista_com_10(client):
 
     planos = mommy.make('PlanoTrabalho',13)
 
-    request = client.get(url_acoesplanotrabalho, HTTP_HOST=host_request,
+    request = client.get(url_acoesplanotrabalho,
             content_type="application/hal+json")
 
     assert isinstance(request.data["_embedded"]["items"], list) 
@@ -156,8 +149,7 @@ def test_acoesplanotrabalho_retorna_404_para_id_nao_valido(client):
 
     url = url_acoesplanotrabalho + '55/'
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     assert request.status_code == status.HTTP_404_NOT_FOUND
 
@@ -169,8 +161,7 @@ def test_acoesplanotrabalho_retorna_para_id_valido(client):
 
     url = url_acoesplanotrabalho + plano_trabalho_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     assert request.status_code == status.HTTP_200_OK
     assert request.data["id"] == plano_trabalho.id
@@ -183,8 +174,7 @@ def test_campos_acoesplanotrabalho(client):
 
     url = url_acoesplanotrabalho + plano_trabalho_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["criacao_lei_sistema_cultura","criacao_orgao_gestor",
         "criacao_plano_cultura","criacao_fundo_cultura","criacao_conselho_cultural",
@@ -199,8 +189,7 @@ def test_objeto_embedded_acoesplanotrabalho(client):
 
     url = url_acoesplanotrabalho + plano_trabalho_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["sistema_cultura_local"])
 
@@ -215,8 +204,7 @@ def test_objeto_criacao_lei_sistema_cultura_acoesplanotrabalho(client):
 
     url = url_acoesplanotrabalho + plano_trabalho_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["lei_sistema_cultura","situacao"])
 
@@ -231,8 +219,7 @@ def test_objeto_criacao_orgao_gestor_acoesplanotrabalho(client):
 
     url = url_acoesplanotrabalho + plano_trabalho_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["relatorio_atividade_secretaria","situacao"])
 
@@ -247,8 +234,7 @@ def test_objeto_criacao_plano_cultura_acoesplanotrabalho(client):
 
     url = url_acoesplanotrabalho + plano_trabalho_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["relatorio_diretrizes_aprovadas","minuta_preparada",
         "ata_reuniao_aprovacao_plano","ata_votacao_projeto_lei",
@@ -265,8 +251,7 @@ def test_objeto_criacao_fundo_cultura_acoesplanotrabalho(client):
 
     url = url_acoesplanotrabalho + plano_trabalho_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["cnpj_fundo_cultura","lei_fundo_cultura","situacao"])
 
@@ -281,8 +266,7 @@ def test_objeto_criacao_conselho_cultural_acoesplanotrabalho(client):
 
     url = url_acoesplanotrabalho + plano_trabalho_id
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     campos = set(["ata_regimento_aprovado","situacao"])
 
@@ -296,8 +280,7 @@ def test_retorno_maximo_de_100_objetos_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + limit_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     assert len(request.data["_embedded"]["items"]) == 100
 
@@ -309,8 +292,7 @@ def test_retorno_maximo_de_100_objetos_acoes_plano_trabalho(client):
 
     url = url_acoesplanotrabalho + limit_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     assert len(request.data["_embedded"]["items"]) == 100
 
@@ -322,8 +304,7 @@ def test_pesquisa_por_cnpj_prefeitura_em_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + cnpj_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     assert len(request.data["_embedded"]["items"]) == 1
     assert request.data["_embedded"]["items"][0]["ente_federado"]["cnpj_prefeitura"] == municipio[0].cnpj_prefeitura
@@ -340,8 +321,7 @@ def test_pesquisa_por_nome_municipio_em_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + nome_municipio_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     assert len(request.data["_embedded"]["items"]) == 1
     assert request.data["_embedded"]["items"][0]["ente_federado"]["localizacao"]["cidade"]["nome_municipio"] == cidades[0].nome_municipio
@@ -355,8 +335,7 @@ def test_pesquisa_por_estado_sigla_em_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + estado_sigla_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     for municipio in request.data["_embedded"]["items"]:
         assert municipio["ente_federado"]["localizacao"]["estado"]["sigla"] == municipios[0].estado.sigla
@@ -375,8 +354,7 @@ def test_pesquisa_por_situacao_adesao_1_em_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + situacao_adesao_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     for municipio in request.data["_embedded"]["items"]:
         assert municipio["situacao_adesao"]["situacao_adesao"] == 'Aguardando envio da documentação' 
@@ -395,8 +373,7 @@ def test_pesquisa_por_situacao_adesao_2_em_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + situacao_adesao_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     for municipio in request.data["_embedded"]["items"]:
         assert municipio["situacao_adesao"]["situacao_adesao"] == 'Documentação Recebida - Aguarda Análise' 
@@ -415,8 +392,7 @@ def test_pesquisa_por_situacao_adesao_3_em_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + situacao_adesao_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     for municipio in request.data["_embedded"]["items"]:
         assert municipio["situacao_adesao"]["situacao_adesao"] == 'Diligência Documental' 
@@ -435,8 +411,7 @@ def test_pesquisa_por_situacao_adesao_4_em_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + situacao_adesao_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     for municipio in request.data["_embedded"]["items"]:
         assert municipio["situacao_adesao"]["situacao_adesao"] == 'Encaminhado para assinatura do Secretário SAI' 
@@ -455,8 +430,7 @@ def test_pesquisa_por_situacao_adesao_5_em_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + situacao_adesao_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     for municipio in request.data["_embedded"]["items"]:
         assert municipio["situacao_adesao"]["situacao_adesao"] == 'Aguarda Publicação no DOU' 
@@ -475,8 +449,7 @@ def test_pesquisa_por_situacao_adesao_6_em_sistema_de_cultura(client):
 
     url = url_sistemadeculturalocal + situacao_adesao_param
 
-    request = client.get(url, HTTP_HOST=host_request,
-            content_type="application/hal+json")
+    request = client.get(url, content_type="application/hal+json")
 
     for municipio in request.data["_embedded"]["items"]:
         assert municipio["situacao_adesao"]["situacao_adesao"] == 'Publicado no DOU' 

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,16 +1,18 @@
 from django.conf.urls import url
+
 from rest_framework.urlpatterns import format_suffix_patterns
+
 from snc.urls import *
 from api import views
 
 urlpatterns = [
-    url(r'^$',views.swagger_index),
+    url(r'^$',views.swagger_index, name='swagger-index'),
 
-    url(r'^v1/sistemadeculturalocal/$', views.MunicipioList.as_view()),
+    url(r'^v1/sistemadeculturalocal/$', views.MunicipioList.as_view(), name='municipio-list'),
     url(r'^v1/sistemadeculturalocal/(?P<pk>[0-9]+)/$', views.MunicipioDetail.as_view(), name='municipio-detail'),
 
     
-    url(r'^v1/acoesplanotrabalho/$', views.PlanoTrabalhoList.as_view()),
+    url(r'^v1/acoesplanotrabalho/$', views.PlanoTrabalhoList.as_view(), name='planotrabalho-list'),
     url(r'^v1/acoesplanotrabalho/(?P<pk>[0-9]+)/$', views.PlanoTrabalhoDetail.as_view(), name='planotrabalho-detail'),
 
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ django-cors-headers==2.1.0
 django-environ==0.4.0
 django-extensions==1.5.5
 django-filter==1.0.4
-django-hosts==2.0
 django-localflavor==1.1
 django-piwik==0.1
 https://pypi.python.org/packages/source/d/django-smart-selects/django-smart-selects-1.1.1.tar.gz

--- a/snc/hosts.py
+++ b/snc/hosts.py
@@ -1,7 +1,0 @@
-from django_hosts import patterns, host
-
-host_patterns = patterns('',
-   host(r'www','snc.urls', name='www'),
-   host(r'api', 'api.urls', name='api'),
-)
-

--- a/snc/settings.py
+++ b/snc/settings.py
@@ -59,7 +59,6 @@ THIRD_PARTY_APPS = (
     'drf_hal_json',
     'rest_framework_xml',
     'rest_framework_csv',
-    'django_hosts',
     'corsheaders',
     'rest_framework_filters'
     
@@ -76,9 +75,6 @@ LOCAL_APPS = (
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
-
-ROOT_HOSTCONF = 'snc.hosts'
-DEFAULT_HOST = 'www'
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'api.pagination.HalLimitOffsetPagination',
@@ -100,14 +96,12 @@ REST_FRAMEWORK = {
 # ------------------------------------------------------------------------------
 MIDDLEWARE_CLASSES = (
     # Make sure djangosecure.middleware.SecurityMiddleware is listed first
-    'django_hosts.middleware.HostsRequestMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django_hosts.middleware.HostsResponseMiddleware',
 )
 
 # Habilita cors somente no urls /v1/

--- a/snc/templates/swagger/index.html
+++ b/snc/templates/swagger/index.html
@@ -1,13 +1,14 @@
 <!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
+{% load static from staticfiles %}
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="static/css/swagger-ui.css" >
-  <link rel="icon" type="image/png" href="static/images/favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="static/images/favicon-16x16.png" sizes="16x16" />
+  <link rel="stylesheet" type="text/css" href="{% static 'css/swagger-ui.css' %}" >
+  <link rel="icon" type="image/png" href="{% static 'images/favicon-32x32.png' %}" sizes="32x32" />
+  <link rel="icon" type="image/png" href="{% static 'images/favicon-16x16.png' %}" sizes="16x16" />
   <style>
     html
     {
@@ -67,14 +68,14 @@
 
 <div id="swagger-ui"></div>
 
-<script src="static/js/swagger-ui-bundle.js"> </script>
-<script src="static/js/swagger-ui-standalone-preset.js"> </script>
+<script src="{% static 'js/swagger-ui-bundle.js' %}"> </script>
+<script src="{% static 'js/swagger-ui-standalone-preset.js' %}"> </script>
 <script>
 window.onload = function() {
   
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "static/swagger/swagger.json",
+      url: "{% static 'swagger/swagger.json' %}",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/snc/urls.py
+++ b/snc/urls.py
@@ -70,4 +70,7 @@ urlpatterns = [
     url(r'^exportar/dados.ods', views.exportar_ods, name='exportar_ods'),
     url(r'^exportar/dados.xls', views.exportar_xls, name='exportar_xls'),
 
+    # API URLS
+    url(r'^api/', include('api.urls', namespace='api')),
+
     ] + static.static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Urls da api agora não se encontram mais no subdomíno "api.". Formato das novas urls:

- /api - Swagger 
- /api/v1/"endpoints" - Acessa os endpoints especificados