### PR TITLE
Issue #82 - Notificação de Nova Adesão

### DIFF
--- a/adesao/tests.py
+++ b/adesao/tests.py
@@ -1,3 +1,57 @@
-from django.test import TestCase
+import pytest
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core import mail 
+from django.conf import settings
+
+from model_mommy import mommy
+
+from .models import Municipio
+
+pytestmark = pytest.mark.django_db
+
+def testa_envio_email_em_nova_adesao(client):
+    user = User.objects.create(username='teste')
+    user.set_password('123456')
+    user.save()
+    usuario = mommy.make('Usuario',user=user)
+
+    estado = mommy.make('Uf')
+    cidade = mommy.make('Cidade')
+
+    login = client.login(username=user.username,password='123456')
+
+    response = client.post('/adesao/municipio/cadastrar/0/', {'estado':estado.codigo_ibge,'cidade':cidade.id,
+        'cnpj_prefeitura':'95.876.554/0001-63', 'cpf_prefeito':'381.390.630-29','uf': estado,
+        'rg_prefeito':'48.464.068-9','orgao_expeditor_rg':'SSP','estado_expeditor':estado.codigo_ibge,
+        'nome_prefeito':'Joao silva','email_institucional_prefeito':'joao@email.com',
+        'endereco_eletronico':'teste.com.br','cep':'60751-110','complemento': 'casa 22',
+        'bairro':'rua teste','telefone_um':'6299999999','endereco':'rua do pao',
+        'termo_posse_prefeito': SimpleUploadedFile('test_file.pdf', bytes('test text','utf-8')),
+        'cpf_copia_prefeito': SimpleUploadedFile('test_file2.pdf', bytes('test text','utf-8')),
+        'rg_copia_prefeito': SimpleUploadedFile('test_file2.pdf', bytes('test text','utf-8')),
+        })
+
+    # Acessa a url de sucesso após o cadastro para fazer o envio do email
+    success_url = client.get(response.url)
+
+    municipio = Municipio.objects.last()
+
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].subject == 'MINISTÉRIO DA CULTURA - SNC - SOLICITAÇÃO NOVA ADESÃO'
+    assert mail.outbox[0].from_email == 'naoresponda@cultura.gov.br'
+    assert mail.outbox[0].to == [settings.RECEIVER_EMAIL]
+    assert mail.outbox[0].body == ('Prezado Gestor,\n' +
+            'Um novo ente federado acabou de se cadastrar e fazer a solicitação de nova adesão.\n' +
+            'Segue abaixo os dados de contato do ente federado:\n\n' +
+            'Dados do Ente Federado:\n' +
+            'Cadastrador: ' + usuario.nome_usuario + '\n' +
+            'Nome do Prefeito: ' + municipio.nome_prefeito + '\n' +
+            'Cidade: ' + cidade.nome_municipio + '\n' +
+            'Estado: ' + estado.sigla + '\n' +
+            'Email Institucional: ' + municipio.email_institucional_prefeito + '\n' +
+            'Telefone de Contato: ' + municipio.telefone_um + '\n' +
+            'Link da Adesão: ' + 'http://snc.cultura.gov.br/gestao/detalhar/municipio/{}'.format(usuario.id) + '\n\n' +
+            'Equipe SNC\nMinistério da Cultura')
+

--- a/env.tmpl
+++ b/env.tmpl
@@ -1,3 +1,4 @@
 DEBUG=True
 DJANGO_EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
 DATABASE_URL=postgres://postgres:postgres123@localhost/dbsnc
+RECEIVER_EMAIL=none@email.com

--- a/snc/settings.py
+++ b/snc/settings.py
@@ -20,6 +20,7 @@ env.read_env()
 
 ROOT_DIR = environ.Path(__file__) - 1  # (/a/b/myfile.py - 3 = /)
 
+RECEIVER_EMAIL = env("RECEIVER_EMAIL", default="none@email.com")
 # DEBUG
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#debug
 DEBUG = env("DEBUG")


### PR DESCRIPTION
Mediante demanda da área negocial, era necessário o envio de um e-mail aos administradores competentes assim que uma nova adesão fosse solicitada.

Para isso fora adicionado um novo método que é acionado assim que uma nova adesão é solicitada.
O método, basicamente, envia um e-mail aos administradores contendo as informações necessárias para que o contato entre as partes seja facilitado.