### PR TITLE
Inclui campo data de adesão e filtro por data

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -9,10 +9,14 @@ class MunicipioFilter(filters.FilterSet):
     nome_municipio = filters.CharFilter(name='cidade__nome_municipio')
     situacao_adesao = filters.CharFilter(name='usuario__estado_processo',
                                          lookup_expr='istartswith')
+    data_adesao = filters.DateFilter(name='usuario__data_publicacao_acordo')
+    data_adesao_min = filters.DateFilter(name='usuario__data_publicacao_acordo', lookup_expr=('gte'))
+    data_adesao_max = filters.DateFilter(name='usuario__data_publicacao_acordo', lookup_expr=('lte'))
 
     class Meta:
         model = Municipio
-        fields = {'id', 'cnpj_prefeitura'}
+        fields = {'id', 'cnpj_prefeitura', 'data_adesao',
+                  'data_adesao_min', 'data_adesao_max'}
 
 
 class PlanoTrabalhoFilter(filters.FilterSet):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -169,12 +169,13 @@ class MunicipioSerializer(hal_serializers.HalModelSerializer):
     conselho = serializers.SerializerMethodField()
     _embedded = serializers.SerializerMethodField(method_name='get_embedded')
     situacao_adesao = serializers.SerializerMethodField()
+    data_adesao = serializers.DateField(source='usuario.data_publicacao_acordo')
     self = HalHyperlinkedIdentityField(view_name='api:municipio-detail')
 
     class Meta:
         model = Municipio
         fields = ('id', 'self', '_embedded', 'ente_federado', 'governo',
-                  'conselho', 'situacao_adesao',)
+                  'conselho', 'situacao_adesao', 'data_adesao')
 
     def get_conselho(self, obj):
 

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,5 +1,6 @@
 import pytest
 import random
+import datetime
 
 from rest_framework import status
 
@@ -32,7 +33,8 @@ def plano_trabalho():
 @pytest.fixture
 def sistema_de_cultura(plano_trabalho):
     municipio = mommy.make('Municipio')
-    mommy.make('Usuario', municipio=municipio, plano_trabalho=plano_trabalho)
+    mommy.make('Usuario', municipio=municipio, plano_trabalho=plano_trabalho,
+               data_publicacao_acordo=datetime.date.today())
 
     return municipio
 
@@ -83,7 +85,8 @@ def test_entidades_principais_sistema_cultura_local(client, sistema_de_cultura):
     request = client.get(url, content_type="application/hal+json")
 
     entidades = set(["governo", "ente_federado", "conselho",
-                     "_embedded", "situacao_adesao", "_links", "id"])
+                     "_embedded", "situacao_adesao", "data_adesao",
+                     "_links", "id"])
 
     assert entidades.symmetric_difference(request.data) == set()
 
@@ -286,6 +289,20 @@ def test_retorno_situacao_conselheiro(client, sistema_de_cultura):
     situacao = request.data["conselho"]["conselheiros"][0]["situacao"]
 
     assert situacao == "Habilitado"
+
+
+def test_retorno_data_adesao_sistema_de_cultura(client, sistema_de_cultura):
+
+    sistema_id = '{}/'.format(sistema_de_cultura.id)
+    url = url_sistemadeculturalocal + sistema_id
+
+    request = client.get(url, content_type="application/hal+json")
+
+    assert request.data["data_adesao"]
+    assert request.data["data_adesao"] == str(sistema_de_cultura.usuario.data_publicacao_acordo)
+
+
+""" Testes de requisições com parâmetros """
 
 
 def test_retorno_maximo_de_100_objetos_sistema_de_cultura(client):


### PR DESCRIPTION
## Descrição
- Retorna campo ```data_adesao``` para o endpoint ```sistemadeculturalocal/```
- Filtra entes federados(```sistemadeculturalocal/```) por data de adesão através dos parâmetros:
  - ```data_adesao``` - Recebe uma data no formato YYYY-MM-DD, e retorna entes federados com a data de adesão igual a passada pela parâmetro
  - ```data_adesao_min``` - Recebe uma data no formato YYYY-MM-DD, e retorna entes federados com a data de adesão maior ou igual a passada como parâmetro.
  - ```data_adesao_max``` - Recebe uma data no formato YYYY-MM-DD, e retorna entes federados com a data de adesão menor ou igual a passada como parâmetro.
  - Ao combinar os dois parâmetros acima é possível retornar os entes federados com a data de adesão com o valor entre os passados pelos parâmetros.