### PR TITLE
Adiciona issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+
+**O pedido de uma nova funcionalidade está relacionado a um problema? Se sim descreva-o**  
+
+Uma descrição clara e concisa de qual é o problema.
+
+**Qual a proposta de solução?**  
+
+Descrição de qual é a funcionalidade que atende a necessidade gerada pelo problema.
+
+**Especificação da funcionalidade**  
+
+Especifique qual a área do sistema afetada e se possível quais interações são necessárias.


### PR DESCRIPTION
Adiciona Issue template para padronizar a criação de issues. O PR foi feito para master pois o github só atualiza o template se estiver na master.