### PR TITLE
Modifica o metodo save de SistemaCultura

### DIFF
--- a/adesao/models.py
+++ b/adesao/models.py
@@ -176,6 +176,33 @@ class SistemaCultura(models.Model):
     cidade = models.ForeignKey("Cidade", on_delete=models.SET_NULL, null=True)
     uf = models.ForeignKey("Uf", on_delete=models.SET_NULL, null=True)
 
+    def compara_valores(self, obj_anterior, propriedade):
+        """
+        Compara os valores de determinada propriedade entre dois objetos.
+        """
+
+        return getattr(obj_anterior, propriedade.attname) == getattr(self, propriedade.attname)
+
+    def save(self, *args, **kwargs):
+        """
+        Salva uma nova instancia de SistemaCultura sempre que alguma informação
+        é alterada.
+        """
+
+        if self.pk:
+            fields = self._meta.fields[1:]
+            anterior = SistemaCultura.objects\
+                    .get(pk=self.pk)
+
+            comparacao = (self.compara_valores(anterior, field) for field in
+                          fields)
+
+            if False in comparacao:
+                self.pk = None
+
+        super(SistemaCultura, self).save(*args, **kwargs)
+
+
     def limpa_cadastrador_alterado(self, cadastrador):
         """
         Remove referência do cadastrador alterado para as tabelas PlanoTrabalho,

--- a/adesao/tests/test_models.py
+++ b/adesao/tests/test_models.py
@@ -38,6 +38,24 @@ def test_atributo_uf_de_um_SistemaCultura():
     assert sistema._meta.get_field('uf')
 
 
+def test_SistemaCultura_save_cria_nova_instancia():
+    """
+    SistemaCultura deve sempre retornar uma nova instancia quando da tentativa
+    de salvar os dados de uma instancia existente.
+    """
+
+    sistema = mommy.make('SistemaCultura')
+    user = mommy.make('Usuario')
+
+    sistema.cadastrador = user
+    sistema.save()
+
+    assert SistemaCultura.objects.count() == 2
+
+    user.delete()
+    [sistema.delete() for sistema in SistemaCultura.objects.all()]
+
+
 def test_alterar_cadastrador_SistemaCultura(plano_trabalho):
     """ Testa método alterar_cadastrador da model SistemaCultura"""
 


### PR DESCRIPTION
Altera o metodo save da model SistemaCultura para que qualquer modificação a uma determinada instancia gere uma nova instancia ao invés de modificar a atual. Assim, é possível manter um histórico de cada alteração ocorrida a um sistema de cultura.