### PR TITLE
[UPDATE] Permite qualquer origem de requisição para a API

### DIFF
--- a/snc/settings.py
+++ b/snc/settings.py
@@ -107,9 +107,7 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
 )
 
-# Habilita cors somente no urls /v1/
 CORS_ORIGIN_ALLOW_ALL = True
-CORS_URLS_REGEX = r'^/v1/.*$'
 
 # MIGRATIONS CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Abre a API para receber requisições de qualquer origem.
Necessário para o VerSNC.