### PR TITLE
Filtra adesões por municipal e estadual

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -12,6 +12,18 @@ class MunicipioFilter(filters.FilterSet):
     data_adesao = filters.DateFilter(name='usuario__data_publicacao_acordo')
     data_adesao_min = filters.DateFilter(name='usuario__data_publicacao_acordo', lookup_expr=('gte'))
     data_adesao_max = filters.DateFilter(name='usuario__data_publicacao_acordo', lookup_expr=('lte'))
+    municipal = filters.BooleanFilter(name='cidade__nome_municipio', method='municipios_filter')
+    estadual = filters.BooleanFilter(name='cidade__nome_municipio', method='municipios_filter')
+
+    def municipios_filter(self, qs, name, value):
+        isnull = not value
+
+        if 'estadual' in self.data.keys():
+            isnull = value
+
+        lookup_expr = name + '__isnull'
+
+        return qs.filter(**{lookup_expr: isnull})
 
     class Meta:
         model = Municipio

--- a/api/tests.py
+++ b/api/tests.py
@@ -54,6 +54,17 @@ def plano_trabalho():
 
 
 @pytest.fixture
+def entes_municipais_estaduais():
+    estadual = mommy.make('Municipio')
+    cidade = mommy.make('Cidade')
+    municipio = mommy.make('Municipio', cidade=cidade)
+
+    yield estadual, municipio
+
+    estadual.delete()
+    municipio.delete()
+
+@pytest.fixture
 def sistema_de_cultura(plano_trabalho):
     municipio = mommy.make('Municipio')
     mommy.make('Usuario', municipio=municipio, plano_trabalho=plano_trabalho,
@@ -653,3 +664,29 @@ def test_choices_situacao_conselheiro(client):
         situacao_list.append({'id': situacao[0], 'description': situacao[1]})
 
     assert request.data['conselho']['situacao']['choices'] == situacao_list
+
+
+def test_retorno_sistemas_cultura_municipios(client, entes_municipais_estaduais):
+    """ Testa retorno de sistema culturas que são referentes a adesões
+    de entes federados municipais """
+    estado, municipio = entes_municipais_estaduais
+    url = url_sistemadeculturalocal + '?municipal=true'
+
+    response = client.get(url)
+    municipio_response = response.data['_embedded']['items'][0]['ente_federado']['localizacao']['cidade']['nome_municipio']
+
+    assert len(response.data['_embedded']['items']) == 1
+    assert municipio_response == municipio.cidade.nome_municipio
+ 
+def test_retorno_sistemas_cultura_estados(client, entes_municipais_estaduais):
+    """ Testa retorno de sistema culturas que são referentes a adesões
+    de entes federados estaduais """
+    estadual, municipio = entes_municipais_estaduais
+    url = url_sistemadeculturalocal + '?estadual=true'
+
+    response = client.get(url)
+    municipio_response = response.data['_embedded']['items'][0]['ente_federado']['localizacao']['estado']['sigla']
+
+    assert len(response.data['_embedded']['items']) == 1
+    assert municipio_response == estadual.estado.sigla
+ 


### PR DESCRIPTION
## Descrição
Filtra adesões municipais e estaduais no retorno do endpoint `sistemadeculturalocal` da API. Os parâmetros de busca são:

- `?municipal` -> Retorna somente adesões municipais ao receber o parâmetro `true`
- `?estadual` -> Retorna somente adesões estaduais ao receber o parâmetro `true`

Co-authored-by: Iza <cizabelacristina@gmail.com>