### PR TITLE
[UPDATE] Filtra sistema cultura ativo por uf e cidade

### DIFF
--- a/adesao/models.py
+++ b/adesao/models.py
@@ -209,8 +209,8 @@ class Historico(models.Model):
 
 
 class SistemaCulturaManager(models.Manager):
-    def ativo(self):
-        return self.latest('data_criacao')
+    def ativo(self, uf, cidade=None):
+        return self.filter(uf=uf, cidade=cidade).latest('data_criacao')
 
 
 class SistemaCultura(models.Model):

--- a/adesao/tests/test_models.py
+++ b/adesao/tests/test_models.py
@@ -132,13 +132,28 @@ def test_manager_usado_SistemaCultura():
     assert isinstance(SistemaCultura.objects.db_manager(), SistemaCulturaManager)
 
 
-def test_retorna_ativo_SistemaCultura():
-    """ Retorna o último Sistema cultura criado sendo ele o ativo """
+def test_retorna_ativo_SistemaCultura_filtrado_por_uf():
+    """ Retorna o último Sistema cultura criado sendo ele o ativo de
+    uma UF específica """
 
     mommy.make('SistemaCultura',
-               data_criacao=datetime(2018, 2, 3, 0, tzinfo=timezone.utc))
-    sistema_ativo = mommy.make('SistemaCultura')
+               data_criacao=datetime(2018, 2, 3, 0, tzinfo=timezone.utc),
+               _fill_optional=['uf'])
+    sistema_ativo = mommy.make('SistemaCultura', _fill_optional=['uf'])
 
-    assert SistemaCultura.objects.ativo() == sistema_ativo
+    assert SistemaCultura.objects.ativo(uf=sistema_ativo.uf) == sistema_ativo
 
     SistemaCultura.objects.all().delete()
+
+
+def test_retorna_ativo_SistemaCultura_filtrado_por_uf_e_cidade():
+    """ Retorna o último Sistema cultura criado sendo ele o ativo de uma
+    UF e cidade específicas """
+
+    mommy.make('SistemaCultura',
+               data_criacao=datetime(2018, 2, 3, 0, tzinfo=timezone.utc),
+               _fill_optional=['uf', 'cidade'])
+    sistema_ativo = mommy.make('SistemaCultura', _fill_optional=['uf', 'cidade'])
+
+    assert SistemaCultura.objects.ativo(
+            uf=sistema_ativo.uf, cidade=sistema_ativo.cidade) == sistema_ativo


### PR DESCRIPTION
## Descrição
Implementa filtro por UF e Cidade de ao retornar um `SistemaCultura` ativo. Sem essa filtragem não seria possível retornar o sistema cultura ativo de um ente federado específico.

 - Issue #188