### PR TITLE
Issue 143 filtrar por data

### DIFF
--- a/gestao/views.py
+++ b/gestao/views.py
@@ -254,8 +254,8 @@ class AcompanharAdesao(ListView):
                 When(usuario__plano_trabalho__criacao_sistema__situacao=1, then=True),
                 default=None,
                 output_field=BooleanField(),
-            )
-        ).order_by('concluido', '-usuario__plano_trabalho__criacao_sistema__data_envio')
+            ),
+        ).order_by('concluido', '-usuario__estado_processo', 'usuario__plano_trabalho__criacao_sistema__data_envio')
 
         return entes
 

--- a/gestao/views.py
+++ b/gestao/views.py
@@ -3,7 +3,7 @@ from threading import Thread
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail import send_mail
 
-from django.db.models import Q
+from django.db.models import Q, Case, When, BooleanField
 
 from django.shortcuts import redirect
 from django.shortcuts import render
@@ -249,7 +249,13 @@ class AcompanharAdesao(ListView):
         else:
             entes = Municipio.objects.all()
 
-        entes = entes.order_by('-usuario__plano_trabalho__criacao_sistema__data_envio')
+        entes = entes.annotate(
+            concluido=Case(
+                When(usuario__plano_trabalho__criacao_sistema__situacao=1, then=True),
+                default=None,
+                output_field=BooleanField(),
+            )
+        ).order_by('concluido', '-usuario__plano_trabalho__criacao_sistema__data_envio')
 
         return entes
 

--- a/gestao/views.py
+++ b/gestao/views.py
@@ -235,19 +235,23 @@ class AcompanharAdesao(ListView):
         ente_federado = self.request.GET.get('municipio', None)
 
         if situacao in ('0', '1', '2', '3', '4', '5', '6'):
-            return Municipio.objects.filter(usuario__estado_processo=situacao)
+            entes = Municipio.objects.filter(usuario__estado_processo=situacao)
 
-        if ente_federado:
+        elif ente_federado:
             municipio = Municipio.objects.filter(
                 cidade__nome_municipio__icontains=ente_federado)
             estado = Municipio.objects.filter(
                 cidade__nome_municipio__isnull=True,
                 estado__nome_uf__icontains=ente_federado)
 
-            return municipio | estado
+            entes = municipio | estado
 
-        return Municipio.objects.all()
+        else:
+            entes = Municipio.objects.all()
 
+        entes = entes.order_by('-usuario__plano_trabalho__criacao_sistema__data_envio')
+
+        return entes
 
 # Acompanhamento dos planos de trabalho
 def diligencia_documental(request, etapa, st, id):


### PR DESCRIPTION
Ordena entes federados, na tela de gestão, dos mais antigos para os mais novos, sendo que os ainda não analisados tem prioridade, assim como os já publicados no DOU, conforme #143 