### PR TITLE
Filtrar por situação dos componentes no sistema de cultura local

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -19,6 +19,23 @@ class MunicipioFilter(filters.FilterSet):
     estadual = filters.BooleanFilter(method='estadual_filter')
     ente_federado = filters.CharFilter(method='ente_federado_filter')
 
+    situacao_conselho_id = filters.NumberFilter(name='usuario__plano_trabalho__conselho_cultural__situacao__id')
+    situacao_orgao_id = filters.NumberFilter(name='usuario__plano_trabalho__orgao_gestor__situacao__id')
+    situacao_lei_id = filters.NumberFilter(name='usuario__plano_trabalho__criacao_sistema__situacao__id')
+    situacao_fundo_id = filters.NumberFilter(name='usuario__plano_trabalho__fundo_cultura__situacao__id')
+    situacao_plano_id = filters.NumberFilter(name='usuario__plano_trabalho__plano_cultura__situacao__id')
+
+    situacao_conselho_descricao = filters.CharFilter(name='usuario__plano_trabalho__conselho_cultural__situacao__descricao',
+                                                     lookup_expr='istartswith')
+    situacao_orgao_descricao = filters.CharFilter(name='usuario__plano_trabalho__orgao_gestor__situacao__descricao',
+                                                  lookup_expr='istartswith')
+    situacao_lei_descricao = filters.CharFilter(name='usuario__plano_trabalho__criacao_sistema__situacao__descricao',
+                                                lookup_expr='istartswith')
+    situacao_fundo_descricao = filters.CharFilter(name='usuario__plano_trabalho__fundo_cultura__situacao__descricao',
+                                                  lookup_expr='istartswith')
+    situacao_plano_descricao = filters.CharFilter(name='usuario__plano_trabalho__plano_cultura__situacao__descricao',
+                                                  lookup_expr='istartswith')
+
     def ente_federado_filter(self, queryset, name, value):
 
         return queryset.filter(

--- a/api/filters.py
+++ b/api/filters.py
@@ -42,22 +42,25 @@ class MunicipioFilter(filters.FilterSet):
 
 
 class PlanoTrabalhoFilter(filters.FilterSet):
-    situacao_conselho_descricao = filters.CharFilter(name='conselho_cultural__situacao_ata__descricao',
+    situacao_conselho_id = filters.NumberFilter(name='conselho_cultural__situacao__id')
+    situacao_conselho_descricao = filters.CharFilter(name='conselho_cultural__situacao__descricao',
                                                      lookup_expr='istartswith')
-    situacao_conselho_id = filters.NumberFilter(name='conselho_cultural__situacao_ata__id')
 
-    situacao_orgao_descricao = filters.CharFilter(name='orgao_gestor__situacao_relatorio_secretaria__descricao',
+    situacao_orgao_id = filters.NumberFilter(name='orgao_gestor__situacao__id')
+    situacao_orgao_descricao = filters.CharFilter(name='orgao_gestor__situacao__descricao',
                                                   lookup_expr='istartswith')
-    situacao_orgao_id = filters.NumberFilter(name='orgao_gestor__situacao_relatorio_secretaria__id')
-    situacao_lei_descricao = filters.CharFilter(name='criacao_sistema__situacao_lei_sistema__descricao',
+
+    situacao_lei_id = filters.NumberFilter(name='criacao_sistema__situacao__id')
+    situacao_lei_descricao = filters.CharFilter(name='criacao_sistema__situacao__descricao',
                                                 lookup_expr='istartswith')
-    situacao_lei_id = filters.CharFilter(name='criacao_sistema__situacao_lei_sistema__id')
-    situacao_fundo_descricao = filters.CharFilter(name='fundo_cultura__situacao_lei_plano__descricao',
+
+    situacao_fundo_id = filters.NumberFilter(name='fundo_cultura__situacao__id')
+    situacao_fundo_descricao = filters.CharFilter(name='fundo_cultura__situacao__descricao',
                                                   lookup_expr='istartswith')
-    situacao_fundo_id = filters.NumberFilter(name='fundo_cultura__situacao_lei_plano__descricao__id')
-    situacao_plano_descricao = filters.CharFilter(name='plano_cultura__situacao_lei_plano__descricao',
+
+    situacao_plano_id = filters.NumberFilter(name='plano_cultura__situacao__id')
+    situacao_plano_descricao = filters.CharFilter(name='plano_cultura__situacao__descricao',
                                                   lookup_expr='istartswith')
-    situacao_plano_id = filters.NumberFilter(name='plano_cultura__situacao_lei_plano__descricao__id')
 
     class Meta:
         model = PlanoTrabalho

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -865,3 +865,48 @@ def test_filtrar_componente_situacao_descricao_acoesplanotrabalho(client, plano_
     response = client.get(url)
 
     assert len(response.data['_embedded']['items']) == 1
+
+
+@pytest.mark.parametrize("query,componente", [
+    ("situacao_lei_id", "criacao_sistema"),
+    ("situacao_orgao_id", "orgao_gestor"),
+    ("situacao_fundo_id", "fundo_cultura"),
+    ("situacao_plano_id", "plano_cultura"),
+    ("situacao_conselho_id", "conselho_cultural"),
+    ])
+def test_filtra_por_situacao_id_componente_sistema_de_cultura(client, plano_trabalho,
+                                                              query, componente):
+    """ Testa retorno ao filtrar sistemas de cultura locais por id da situação
+    dos componentes do plano de trabalho """
+
+    mommy.make('Municipio', _quantity=2)
+    situacao = getattr(plano_trabalho, componente).situacao
+
+    url = url_sistemadeculturalocal + '?{}={}'.format(query, situacao.id)
+
+    response = client.get(url)
+
+    assert len(response.data['_embedded']['items']) == 1
+
+
+@pytest.mark.parametrize("query,componente", [
+    ("situacao_lei_descricao", "criacao_sistema"),
+    ("situacao_orgao_descricao", "orgao_gestor"),
+    ("situacao_fundo_descricao", "fundo_cultura"),
+    ("situacao_plano_descricao", "plano_cultura"),
+    ("situacao_conselho_descricao", "conselho_cultural"),
+    ])
+def test_filtra_por_situacao_descricao_componente_sistema_de_cultura(client,
+                                                                     plano_trabalho,
+                                                                     query, componente):
+    """ Testa retorno ao filtrar sistemas de cultura locais por descrição da situação
+    dos componentes do plano de trabalho """
+
+    mommy.make('Municipio', _quantity=2)
+    situacao = getattr(plano_trabalho, componente).situacao
+
+    url = url_sistemadeculturalocal + '?{}={}'.format(query, situacao.descricao)
+
+    response = client.get(url)
+
+    assert len(response.data['_embedded']['items']) == 1

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -821,3 +821,47 @@ def test_filtrar_por_nome_ente_federado_vazio(client):
     response = client.get(url)
 
     assert len(response.data['_embedded']['items']) == 1
+
+
+@pytest.mark.parametrize("query,componente", [
+    ("situacao_lei_id", "criacao_sistema"),
+    ("situacao_orgao_id", "orgao_gestor"),
+    ("situacao_fundo_id", "fundo_cultura"),
+    ("situacao_plano_id", "plano_cultura"),
+    ("situacao_conselho_id", "conselho_cultural"),
+    ])
+def test_filtrar_componente_situacao_id_acoesplanotrabalho(client, plano_trabalho,
+                                                           query, componente):
+    """ Testa retorno ao filtrar por id do componente do plano de trabalho
+    no endpoint acoesplanotrabalho """
+
+    mommy.make('Municipio', _quantity=2)
+    situacao = getattr(plano_trabalho, componente).situacao
+
+    url = url_acoesplanotrabalho + '?{}={}'.format(query, situacao.id)
+
+    response = client.get(url)
+
+    assert len(response.data['_embedded']['items']) == 1
+
+
+@pytest.mark.parametrize("query,componente", [
+    ("situacao_lei_descricao", "criacao_sistema"),
+    ("situacao_orgao_descricao", "orgao_gestor"),
+    ("situacao_fundo_descricao", "fundo_cultura"),
+    ("situacao_plano_descricao", "plano_cultura"),
+    ("situacao_conselho_descricao", "conselho_cultural"),
+    ])
+def test_filtrar_componente_situacao_descricao_acoesplanotrabalho(client, plano_trabalho,
+                                                                  query, componente):
+    """ Testa retorno ao filtrar por descrição componente do plano de trabalho
+    no endpoint acoesplanotrabalho """
+
+    mommy.make('Municipio', _quantity=2)
+    situacao = getattr(plano_trabalho, componente).situacao
+
+    url = url_acoesplanotrabalho + '?{}={}'.format(query, situacao.descricao)
+
+    response = client.get(url)
+
+    assert len(response.data['_embedded']['items']) == 1


### PR DESCRIPTION
## Descrição
Adiciona filtragem de sistemas de cultura locais(`/sistemadeculturalocal`) por situação dos componentes do plano de trabalho dos entes federados, através dos parâmetros:
  - Pelo ID da situação:
    - `?situacao_lei_id`
    - `?situacao_orgao_id`
    - `?situacao_fundo_id`
    - `?situacao_plano_id`
    - `?situacao_conselho_id`
  - Pela descrição da situação:
    - `?situacao_lei_descricao`
    - `?situacao_orgao_descricao`
    - `?situacao_fundo_descricao`
    - `?situacao_plano_descricao`
    - `?situacao_conselho_descricao`

Corrigido também os campos utilizados para filtrar situação.

## Issues #209 e #212 