### PR TITLE
246 pesquisa api

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -49,7 +49,10 @@ class MunicipioFilter(filters.FilterSet):
         return queryset.filter(
                 Q(estado__sigla__istartswith=value) |
                 Q(estado__nome_uf__istartswith=value) |
-                Q(cidade__nome_municipio__istartswith=value))
+                Q(estado__nome_uf__unaccent__icontains=value) |
+                Q(cidade__nome_municipio__istartswith=value) |
+                Q(cidade__nome_municipio__unaccent__icontains=value)
+                )
 
     def estadual_filter(self, queryset, name, value):
 

--- a/api/filters.py
+++ b/api/filters.py
@@ -11,8 +11,8 @@ from planotrabalho.models import SituacoesArquivoPlano
 class MunicipioFilter(filters.FilterSet):
 
     estado_sigla = filters.CharFilter(field_name='estado__sigla', lookup_expr='iexact')
-    nome_uf = filters.CharFilter(field_name='estado__nome_uf', lookup_expr='iexact')
-    nome_municipio = filters.CharFilter(field_name='cidade__nome_municipio', lookup_expr='iexact')
+    nome_uf = filters.CharFilter(field_name='estado__nome_uf__unaccent', lookup_expr='iexact')
+    nome_municipio = filters.CharFilter(field_name='cidade__nome_municipio__unaccent', lookup_expr='iexact')
     situacao_adesao = filters.CharFilter(field_name='usuario__estado_processo',
                                          lookup_expr='istartswith')
     data_adesao = filters.DateFilter(field_name='usuario__data_publicacao_acordo')

--- a/api/migrations/0001_initial.py
+++ b/api/migrations/0001_initial.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+from django.contrib.postgres.operations import UnaccentExtension
+
+# Adiciona a extensão UnaccentExtension para tratar pesquisas na API
+# em strings que tenham acento 
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        UnaccentExtension()
+    ]

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -1274,3 +1274,16 @@ def test_filtra_componente_plano_por_multiplos_ids_situacao(client):
     for componentes in response.data['_embedded']['items']:
         situacao = componentes['_embedded']['acoes_plano_trabalho']['criacao_plano_cultura']['situacao']
         assert situacao == 'Avaliando anexo' or situacao == 'Em preenchimento' 
+
+
+def test_pesquisa_por_nome_municipio_para_municipios_com_acento_no_nome(client):
+    ''' Pesquisa (sem acento) o nome de um municpio que tenha acento - Deve retornar normalmente'''
+    mommy.make('Municipio', cidade=mommy.make('Cidade', nome_municipio='Acrelândia'))
+
+    nome_municipio_param = '?nome_municipio={}'.format('Acrelandia')
+
+    url = url_sistemadeculturalocal + nome_municipio_param
+
+    request = client.get(url, content_type="application/hal+json")
+    assert len(request.data["_embedded"]["items"]) == 0
+    assert request.data["_embedded"]["items"][0]["ente_federado"]["localizacao"]["cidade"]["nome_municipio"] == 'Acrelândia'

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -1285,5 +1285,16 @@ def test_pesquisa_por_nome_municipio_para_municipios_com_acento_no_nome(client):
     url = url_sistemadeculturalocal + nome_municipio_param
 
     request = client.get(url, content_type="application/hal+json")
-    assert len(request.data["_embedded"]["items"]) == 0
+    assert len(request.data["_embedded"]["items"]) == 1
     assert request.data["_embedded"]["items"][0]["ente_federado"]["localizacao"]["cidade"]["nome_municipio"] == 'Acrelândia'
+
+def test_pesquisa_por_nome_estado_para_estados_com_acento_no_nome(client):
+    ''' Pesquisa (sem acento) o nome de um municpio que tenha acento - Deve retornar normalmente'''
+    mommy.make('Municipio', estado=mommy.make('Uf', nome_uf='Goiás'))
+
+    nome_municipio_param = '?nome_uf={}'.format('Goias')
+
+    url = url_sistemadeculturalocal + nome_municipio_param
+
+    request = client.get(url, content_type="application/hal+json")
+    assert request.data["_embedded"]["items"][0]["ente_federado"]["localizacao"]['estado']['nome_uf'] == 'Goiás'


### PR DESCRIPTION
Permite pesquisa por nomes sem acento na API para os seguintes filtros:
- Nome do Município - /?nome_municipio
- Nome da Uf - /?nome_uf
- Ente Federado (estado ou município) - /?ente_federado