### PR TITLE
Corrige link para download dos planos de cultura

### DIFF
--- a/gestao/templates/detalhe_municipio.html
+++ b/gestao/templates/detalhe_municipio.html
@@ -239,7 +239,7 @@
           </div>
 
           <div class="list-group-item col-xs-2 text-center">
-            <a href="{{ ente.plano_cultura.arquivo.url}}">Download</a>
+            <a href="{{ ente.plano.arquivo.url}}">Download</a>
           </div>
           {% if ente.plano.situacao == 1 %}
 

--- a/gestao/tests/test_views.py
+++ b/gestao/tests/test_views.py
@@ -1800,8 +1800,6 @@ def test_ente_federado_nao_encontrado(client, login_staff):
     url = reverse("gestao:acompanhar_adesao") + "?ente_federado=aaaa"
     response = client.get(url)
 
-    print(response.content)
-
     assert len(response.context_data["object_list"]) == 0
 
 

--- a/gestao/tests/test_views.py
+++ b/gestao/tests/test_views.py
@@ -1787,6 +1787,7 @@ def test_historico_diligencias_componentes(client, login_staff):
     assert len(historico) == 1
     assert historico[0].diligencia == diligencia
 
+
 def test_ente_federado_nao_encontrado(client, login_staff):
     """ Testa se pesquisa retorna um ente federado.
     """
@@ -1799,4 +1800,45 @@ def test_ente_federado_nao_encontrado(client, login_staff):
     url = reverse("gestao:acompanhar_adesao") + "?ente_federado=aaaa"
     response = client.get(url)
 
+    print(response.content)
+
     assert len(response.context_data["object_list"]) == 0
+
+
+def test_links_para_componentes(client, login_staff):
+
+    sistema = mommy.make(
+        "SistemaCultura", ente_federado__cod_ibge=123456, estado_processo=6,
+        _fill_optional=['legislacao', 'orgao_gestor', 'plano', 'fundo_cultura', 'conselho']
+    )
+
+    arquivo = SimpleUploadedFile("lei.txt", b"file_content", content_type="text/plain")
+
+    sistema.legislacao.tipo = 0
+    sistema.legislacao.arquivo = arquivo
+    sistema.legislacao.save()
+
+    sistema.orgao_gestor.tipo = 1
+    sistema.orgao_gestor.arquivo = arquivo
+    sistema.orgao_gestor.save()
+
+    sistema.fundo_cultura.tipo = 2
+    sistema.fundo_cultura.arquivo = arquivo
+    sistema.fundo_cultura.save()
+
+    sistema.conselho.tipo = 3
+    sistema.conselho.arquivo = arquivo
+    sistema.conselho.save()
+
+    sistema.plano.tipo = 4
+    sistema.plano.arquivo = arquivo
+    sistema.plano.save()
+
+    url = reverse("gestao:detalhar", kwargs={"cod_ibge": sistema.ente_federado.cod_ibge})
+    response = client.get(url)
+
+    assert "<a href=\"/media/" + sistema.legislacao.arquivo.name + "\">Download</a>" in response.rendered_content
+    assert "<a href=\"/media/" + sistema.orgao_gestor.arquivo.name + "\">Download</a>" in response.rendered_content
+    assert "<a href=\"/media/" + sistema.fundo_cultura.arquivo.name + "\">Download</a>" in response.rendered_content
+    assert "<a href=\"/media/" + sistema.conselho.arquivo.name + "\">Download</a>" in response.rendered_content
+    assert "<a href=\"/media/" + sistema.plano.arquivo.name + "\">Download</a>" in response.rendered_content

--- a/snc/templates/consultar/detalhar.html
+++ b/snc/templates/consultar/detalhar.html
@@ -374,7 +374,7 @@
                                     {% endif %}
                                 </div>
                                 <div id="parent-fieldname-description" class="documentDescription" style="color:#ffffff">
-                                    {% if object.plano.arquivo == 2 or object.plano.arquivo == 3 %}
+                                    {% if object.plano.situacao == 2 or object.plano.situacao == 3 %}
                                     <i class="fa fa-check"></i>
                                     <a href="{{ object.plano.arquivo.url }}" style="color:#ffffff">
                                         Lei do Plano de Cultura


### PR DESCRIPTION
- Corrige acesso ao atributo plano, no link para download 
- Corrige acesso à situação do plano, na tela de consulta de informações do ente
- Adiciona testes que verificam se os links para download foram gerados corretamente para cada componente

Closes #376 #375 