### PR TITLE
Altera a view Detalhar pra usar cod_ibge

### DIFF
--- a/adesao/templates/templated_email/adesao.email
+++ b/adesao/templates/templated_email/adesao.email
@@ -11,7 +11,7 @@ Nome do Prefeito: {{form_data.nome}}
 Estado: {{object.ente_federado.nome}}{% endif %}
 Email Institucional: {{form_data.email_institucional}}
 Telefone de Contato: {{form_data.telefone_um}}
-Link da Adesão: http://snc.cultura.gov.br/gestao/detalhar/{{sistema_atualizado.id}}
+Link da Adesão: http://snc.cultura.gov.br/gestao/detalhar/{{sistema_atualizado.ente_federado.cod_ibge}}
 
 Equipe SNC
 SECRETARIA ESPECIAL DA CULTURA / MINISTÉRIO DA CIDADANIA{% endblock %}

--- a/adesao/tests/test_views.py
+++ b/adesao/tests/test_views.py
@@ -98,7 +98,7 @@ Nome do Prefeito: {sistema.gestor.nome}
 Cidade: {sistema.ente_federado.nome}
 Email Institucional: {sistema.gestor.email_institucional}
 Telefone de Contato: {sistema.sede.telefone_um}
-Link da Adesão: http://snc.cultura.gov.br/gestao/detalhar/{sistema.id}
+Link da Adesão: http://snc.cultura.gov.br/gestao/detalhar/{sistema.ente_federado.cod_ibge}
 
 Equipe SNC
 SECRETARIA ESPECIAL DA CULTURA / MINISTÉRIO DA CIDADANIA"""

--- a/adesao/tests/test_views.py
+++ b/adesao/tests/test_views.py
@@ -539,10 +539,11 @@ def test_importar_secretario_id_invalido(client, login):
 
 
 def test_detalhar_conselheiros(client):
-    sistema_cultura = mommy.make("SistemaCultura", _fill_optional=['conselho'])
+    sistema_cultura = mommy.make("SistemaCultura", _fill_optional=['conselho', 'ente_federado'],
+        ente_federado__cod_ibge=123456)
     conselheiro = mommy.make("Conselheiro", conselho=sistema_cultura.conselho)
 
-    url = reverse("adesao:detalhar", kwargs={'pk': sistema_cultura.id})
+    url = reverse("adesao:detalhar", kwargs={'cod_ibge': sistema_cultura.ente_federado.cod_ibge})
     response = client.get(url)
 
     assert response.context_data['conselheiros'][0] == conselheiro

--- a/adesao/urls.py
+++ b/adesao/urls.py
@@ -66,5 +66,5 @@ urlpatterns = [
 
     # Consulta
     path('consultar/<str:tipo>', views.ConsultarEnte.as_view(), name='consultar'),
-    url(r'^detalhar/(?P<pk>[0-9]+)$', views.Detalhar.as_view(), name='detalhar'),
+    path('detalhar/<int:cod_ibge>', views.Detalhar.as_view(), name='detalhar'),
     ]

--- a/adesao/views.py
+++ b/adesao/views.py
@@ -573,6 +573,12 @@ class Detalhar(DetailView):
     model = SistemaCultura
     template_name = "consultar/detalhar.html"
 
+    def get_object(self):
+        try:
+            return SistemaCultura.sistema.get(ente_federado__cod_ibge=self.kwargs['cod_ibge'])
+        except:
+            raise Http404()
+
     def get_context_data(self, **kwargs):
         context = super(Detalhar, self).get_context_data(**kwargs)
         try:

--- a/snc/templates/consultar/consultar.html
+++ b/snc/templates/consultar/consultar.html
@@ -75,7 +75,7 @@
 <ul>
   {% for sistema in object_list %}
   <li>
-    <a href="{% url 'adesao:detalhar' sistema.id %}">{{ sistema.ente_federado }}</a>
+    <a href="{% url 'adesao:detalhar' cod_ibge=sistema.ente_federado.cod_ibge %}">{{ sistema.ente_federado }}</a>
   </li>
   {% empty %}
   <li>


### PR DESCRIPTION
Como a view Detalhar usava o id do sistemacultura como pk, os links para os entes federados ficavam mudando, uma vez que é gerado um novo sistemacultura quando este é alterado, portanto, a view foi alterado para buscar o objeto a ser detalhado pelo código IBGE do ente federado, que é único.