### PR TITLE
permite usuário sempre trocar o comprovante de cnpj ao alterar o Órgã…

### DIFF
--- a/planotrabalho/forms.py
+++ b/planotrabalho/forms.py
@@ -105,6 +105,7 @@ class CriarOrgaoGestorForm(CriarComponenteForm):
     cnpj = BRCNPJField(required=False)
     #comprovante = forms.FileField(required=False, widget=FileInput)
     arquivo = forms.FileField(required=False, widget=FileInput)
+    comprovante_cnpj_orgao = forms.FileField(required=False, widget=FileInput)
     banco = forms.ChoiceField(required=False, choices=BANCOS)
     agencia = forms.CharField(required=False, max_length=4) 
     conta = forms.CharField(required=False, max_length=20)

--- a/snc/templates/planotrabalho/cadastrar_fundo.html
+++ b/snc/templates/planotrabalho/cadastrar_fundo.html
@@ -80,12 +80,8 @@
       </label>
       {% if form.comprovante.value %}
         <p><a href="{{ form.comprovante.value.url }}" target="_blank">Baixar arquivo atual</a></p>
-        {% if form.sistema.sistema.fundo_cultura.comprovante.situacao != 2 %}
-          <p>Modificar: {% render_field form.comprovante %}</p>
         {% endif %}
-      {% else %}
-        <p>{% render_field form.comprovante %}</p>
-      {% endif %}
+      <p>{% render_field form.comprovante %}</p>
     </div>
      <label for="{{ form.comprovante.id_for_label }}">
         Banco

--- a/snc/templates/planotrabalho/cadastrar_orgao.html
+++ b/snc/templates/planotrabalho/cadastrar_orgao.html
@@ -29,12 +29,12 @@
       Normativo que cria a estrutura do Órgão Gestor de Cultura no âmbito do estado ou município
     </label>
     {% if form.arquivo.value %}
-    <p><a href="{{ form.arquivo.value.url }}" target="_blank">Baixar arquivo atual</a></p>
-    {% if form.sistema.orgao_gestor.situacao != 2 %}
-    <p>Modificar: {% render_field form.arquivo %}</p>
-    {% endif %}
-    {% else %}
-    <p>{% render_field form.arquivo %}</p>
+      <p><a href="{{ form.arquivo.value.url }}" target="_blank">Baixar arquivo atual</a></p>
+      {% if form.sistema.orgao_gestor.situacao != 2 %}
+        <p>Modificar: {% render_field form.arquivo %}</p>
+      {% endif %}
+      {% else %}
+      <p>{% render_field form.arquivo %}</p>
     {% endif %}
   </div>
 
@@ -75,12 +75,8 @@
       </label>
       {% if form.comprovante_cnpj_orgao.value %}
         <p><a href="{{ form.comprovante_cnpj_orgao.value.url }}" target="_blank">Baixar arquivo atual</a></p>
-        {% if form.sistema.sistema.fundo_cultura.comprovante.situacao != 2 %}
-          <p>Modificar: {% render_field form.comprovante_cnpj_orgao %}</p>
-        {% endif %}
-      {% else %}
-        <p>{% render_field form.comprovante_cnpj_orgao %}</p>
       {% endif %}
+      <p>{% render_field form.comprovante_cnpj_orgao %}</p>
     </div>
     <label for="{{ form.comprovante.id_for_label }}">
         Banco


### PR DESCRIPTION
Permite que o usuário reenvie o comprovante de CNPJ no Órgão Gestor e no Fundo de Cultura