### PR TITLE
Lei de criação do Fundo de Cultura: agencia e conta

### DIFF
--- a/planotrabalho/forms.py
+++ b/planotrabalho/forms.py
@@ -458,6 +458,8 @@ class CriarFundoForm(ModelForm):
         return self.cleaned_data['comprovante']
 
     def clean_agencia(self):
+        if self.data.get('possui_cnpj', None) == 'False':
+            return ''
         cleaned_data = self.clean()
         num_agencia = cleaned_data.get('agencia')
         if not num_agencia.isdigit():
@@ -465,6 +467,8 @@ class CriarFundoForm(ModelForm):
         return num_agencia
 
     def clean_conta(self):
+        if self.data.get('possui_cnpj', None) == 'False':
+            return ''
         cleaned_data = self.clean()
         num_conta = cleaned_data.get('conta')
         num_conta = num_conta.replace('-','')

--- a/snc/templates/planotrabalho/cadastrar_fundo.html
+++ b/snc/templates/planotrabalho/cadastrar_fundo.html
@@ -53,7 +53,7 @@
 
   <div class="form-group">
     <label for="{{ form.possui_cnpj.id_for_label }}">
-      O Fundo de Cultura possui ?</br>
+      O Fundo de Cultura possui CNPJ?</br>
     </label>
     {% if form.sistema.fundo_cultura.comprovante_cnpj.situacao != 2 %}
       {% render_field form.possui_cnpj class="radio" %}


### PR DESCRIPTION
Corrige bug que exigia agência e conta mesmo o usuário selecionando 'não' para o field O Fundo de Cultura possui CNPJ?;
altera texto 'O Fundo de Cultura possui ?' para 'O Fundo de Cultura possui CNPJ?'

 
